### PR TITLE
COG indices for AI rockfish

### DIFF
--- a/R/aesthetics.R
+++ b/R/aesthetics.R
@@ -1,0 +1,33 @@
+#' Custom aesthetics, mostly from theme_sleek() from ggsidekick 
+#' (github.com/seananderson/ggsidekick), and custom plot colors for the time
+#' series. These are explicity listed to avoid including non-CRAN packages in
+#' the main code.
+
+# Create ggplot theme
+theme_sleek <- function(base_size = 11, base_family = "") {
+  half_line <- base_size/2
+  theme_light(base_size = base_size, base_family = base_family) +
+    theme(
+      panel.grid.major = element_blank(),
+      panel.grid.minor = element_blank(),
+      axis.ticks.length = unit(half_line / 2.2, "pt"),
+      strip.background = element_rect(fill = NA, colour = NA),
+      strip.text.x = element_text(colour = "grey30"),
+      strip.text.y = element_text(colour = "grey30"),
+      axis.text = element_text(colour = "grey30"),
+      axis.title = element_text(colour = "grey30"),
+      legend.title = element_text(colour = "grey30", size = rel(0.9)),
+      panel.border = element_rect(fill = NA, colour = "grey70", linewidth = 1),
+      legend.key.size = unit(0.9, "lines"),
+      legend.text = element_text(size = rel(0.7), colour = "grey30"),
+      legend.key = element_rect(colour = NA, fill = NA),
+      legend.background = element_rect(colour = NA, fill = NA),
+      plot.title = element_text(colour = "grey30", size = rel(1)),
+      plot.subtitle = element_text(colour = "grey30", size = rel(.85))
+    )
+}
+
+theme_set(theme_sleek())  # set theme for all plots
+
+# Special colors from naturalparkcolors::park_palette("Saguaro)
+pal <- c("#847CA3", "#E45A5A", "#F4A65E", "#80792B", "#F2D56F", "#1A1237")

--- a/R/aesthetics.R
+++ b/R/aesthetics.R
@@ -30,4 +30,7 @@ theme_sleek <- function(base_size = 11, base_family = "") {
 theme_set(theme_sleek())  # set theme for all plots
 
 # Special colors from naturalparkcolors::park_palette("Saguaro)
-pal <- c("#847CA3", "#E45A5A", "#F4A65E", "#80792B", "#F2D56F", "#1A1237")
+# pal <- c("#847CA3", "#E45A5A", "#F4A65E", "#80792B", "#F2D56F", "#1A1237")
+
+# Custom palette
+pal <- c("#18377a", "#533549", "#d590da", "#be3144", "#ff7844", "#e3d26f")

--- a/R/cog.R
+++ b/R/cog.R
@@ -20,12 +20,6 @@ if (file.exists("Z:/Projects/ConnectToOracle.R")) {
   channel <- gapindex::get_connected(check_access = FALSE)
 }
 
-## TODO: Set survey area
-survey <- c("AI", "GOA")[1]
-
-## TODO: Set latest GOA or AI survey year
-yr <- 2024
-
 ## Define species and species groupings
 rf_groups <- data.frame(
   GROUP_CODE   = c(30060, 30050, 30050, 30050, 30576, 30420, 30152, 30020),

--- a/R/cog.R
+++ b/R/cog.R
@@ -20,8 +20,11 @@ if (file.exists("Z:/Projects/ConnectToOracle.R")) {
   channel <- gapindex::get_connected(check_access = FALSE)
 }
 
-## TODO: Set latest GOA survey year
-yr_goa <- 2025
+## TODO: Set survey area
+survey <- c("AI", "GOA")[1]
+
+## TODO: Set latest GOA or AI survey year
+yr <- 2023
 
 ## Define species and species groupings
 rf_groups <- data.frame(
@@ -30,13 +33,25 @@ rf_groups <- data.frame(
 )
 
 ## Pull data
-gp_data <- 
-  gapindex::get_data(year_set = c(seq(from = 1990, to = 1999, by = 3),
-                                  seq(from = 2003, to = yr_goa, by = 2)),
-                     survey_set = "GOA",
-                     spp_codes = rf_groups,
-                     channel = channel
-  )
+if(survey == "GOA") {
+  gp_data <- 
+    gapindex::get_data(year_set = c(seq(from = 1990, to = 1999, by = 3),
+                                    seq(from = 2003, to = yr, by = 2)),
+                       survey_set = survey,
+                       spp_codes = rf_groups,
+                       channel = channel
+    )
+} 
+
+if(survey == "AI") {
+  gp_data <- 
+    gapindex::get_data(year_set = c(seq(from = 1991, to = 2000, by = 3),
+                                    seq(from = 2002, to = yr, by = 2)),
+                       survey_set = survey,
+                       spp_codes = rf_groups,
+                       channel = channel
+    )
+}
 
 ## Calculate cpue
 gp_cpue <- gapindex::calc_cpue(gapdata = gp_data) |> as.data.frame()
@@ -95,4 +110,4 @@ for (imetric in c("DEPTH_M", "BOTTOM_TEMPERATURE_C",
     ) 
 }
 
-write.csv(cogs, here::here("output", paste0("rf_cogs_", yr_goa, ".csv")), row.names = FALSE)
+write.csv(cogs, here::here("output", paste0("rf_cogs_", survey, "_", yr, ".csv")), row.names = FALSE)

--- a/R/cog.R
+++ b/R/cog.R
@@ -24,7 +24,7 @@ if (file.exists("Z:/Projects/ConnectToOracle.R")) {
 survey <- c("AI", "GOA")[1]
 
 ## TODO: Set latest GOA or AI survey year
-yr <- 2023
+yr <- 2024
 
 ## Define species and species groupings
 rf_groups <- data.frame(
@@ -56,7 +56,6 @@ if(survey == "AI") {
 ## Calculate cpue
 gp_cpue <- gapindex::calc_cpue(gapdata = gp_data) |> as.data.frame()
 
-
 calc_weighted_mean <- function(x, w, lwr_p = 0.025, upr_p = 0.975) {
   ## Count the number of records that have a positive weight (w) 
   ## and a metric (some metrics are missing from some hauls) 
@@ -83,11 +82,21 @@ calc_weighted_mean <- function(x, w, lwr_p = 0.025, upr_p = 0.975) {
   )
 }
 
+## Translate latitude and longitdue to UTM
+utm <- sf::st_as_sf(
+  cbind.data.frame(X = gp_cpue$LONGITUDE_DD_START, 
+                   Y = gp_cpue$LATITUDE_DD_START), 
+  coords = c("X", "Y"), 
+  crs = 4326)
+utm <- sf::st_transform(utm, "+proj=utm +zone=5 +datum=WGS84 +units=km")
+utm <- data.frame(sf::st_coordinates(utm))
+
+gp_cpue <- cbind.data.frame(gp_cpue, X = utm$X, Y = utm$Y)
+
 ## Loop over metrics and calculate weighted means, SEs, and CIs 
 ## for each species and year
 cogs <- data.frame()
-for (imetric in c("DEPTH_M", "BOTTOM_TEMPERATURE_C", 
-                  "LATITUDE_DD_START", "LONGITUDE_DD_START")){
+for (imetric in c("DEPTH_M", "BOTTOM_TEMPERATURE_C", "X", "Y")){
   cogs <- 
     rbind(cogs,
           data.frame(

--- a/R/cog.R
+++ b/R/cog.R
@@ -20,6 +20,9 @@ if (file.exists("Z:/Projects/ConnectToOracle.R")) {
   channel <- gapindex::get_connected(check_access = FALSE)
 }
 
+# Set year to current year
+yr <- as.numeric(format(Sys.Date(), "%Y"))
+
 ## Define species and species groupings
 rf_groups <- data.frame(
   GROUP_CODE   = c(30060, 30050, 30050, 30050, 30576, 30420, 30152, 30020),
@@ -76,16 +79,20 @@ calc_weighted_mean <- function(x, w, lwr_p = 0.025, upr_p = 0.975) {
   )
 }
 
-## Translate latitude and longitdue to UTM
-utm <- sf::st_as_sf(
+## Translate latitude and longitdue to Alaska Albers
+aa <- sf::st_as_sf(
   cbind.data.frame(X = gp_cpue$LONGITUDE_DD_START, 
                    Y = gp_cpue$LATITUDE_DD_START), 
   coords = c("X", "Y"), 
   crs = 4326)
-utm <- sf::st_transform(utm, "+proj=utm +zone=5 +datum=WGS84 +units=km")
-utm <- data.frame(sf::st_coordinates(utm))
+aa <- sf::st_transform(aa, crs = 3338)
+aa <- data.frame(sf::st_coordinates(aa))
 
-gp_cpue <- cbind.data.frame(gp_cpue, X = utm$X, Y = utm$Y)
+gp_cpue <- cbind.data.frame(gp_cpue, X = aa$X, Y = aa$Y)
+
+# Convert eastings/northings from meters to kilometers
+gp_cpue$X <- gp_cpue$X / 1000
+gp_cpue$Y <- gp_cpue$Y / 1000
 
 ## Loop over metrics and calculate weighted means, SEs, and CIs 
 ## for each species and year

--- a/R/cog_plots.R
+++ b/R/cog_plots.R
@@ -71,7 +71,7 @@ ts_plot <- ggplot(cogs_plot, aes(x = year, y = est)) +
   scale_fill_manual(values = pal) +
   scale_y_continuous(labels = function(est) abs(est)) +
   facet_wrap(~ metric, scales = "free_y") 
-ts_plot
+ts_plot  # view plot
 
 
 # Sparkleplot (bivariate scatter plot for lat & lon) --------------------------
@@ -125,6 +125,7 @@ if(survey == "GOA") {
   cog_sparkle <- cog_latlon
 }
 
+# Build layered plot, so more recent years are on top
 # Build the base plot with facets and scales (but no data layers yet)
 years_ordered <- sort(unique(cog_sparkle$year)) # List of years
 sparkle <- ggplot(cog_sparkle, aes(color = year)) +
@@ -163,73 +164,73 @@ if(survey == "AI") {
   sparkle <- sparkle + 
     scale_x_continuous(breaks = c(-185, -180, -175), labels = c(175, 0, -175)) 
 }
-sparkle
+sparkle  # view plot
 
 
 # Maps ------------------------------------------------------------------------
 world <- rnaturalearth::ne_countries(scale = "medium", returnclass = "sf")
-sf::sf_use_s2(FALSE)  # turn off spherical geometry
+sf::sf_use_s2(FALSE) # turn off spherical geometry
 
 if(survey == "AI") {
-  # Subset world to Aleutian Islands region
+  # Subset world to the Aleutians (split along IDL, then stitch back together)
   western_half <- sf::st_crop(world, xmin = 170, xmax = 180, ymin = 48, ymax = 55)
   eastern_half <- sf::st_crop(world, xmin = -180, xmax = -170, ymin = 48, ymax = 55)
-  aleutians_full <- bind_rows(western_half, eastern_half) %>%
-    sf::st_shift_longitude() 
+  map_bg <- bind_rows(western_half, eastern_half) %>%
+    sf::st_shift_longitude()
   
   # Transform data to continuous scale across date line for plotting
-  cog_360 <- cog_latlon %>%
-    mutate(lon_360 = ifelse(est_lon < 0, est_lon + 360, est_lon),
-           lwr_360 = ifelse(lwr_lon < 0, lwr_lon + 360, lwr_lon),
-           upr_360 = ifelse(upr_lon < 0, upr_lon + 360, upr_lon))
+  map_data <- cog_latlon %>%
+    mutate(x_plot = ifelse(est_lon < 0, est_lon + 360, est_lon),
+           xmin_plot = ifelse(lwr_lon < 0, lwr_lon + 360, lwr_lon),
+           xmax_plot = ifelse(upr_lon < 0, upr_lon + 360, upr_lon),
+           y_plot = est_lat)
   
-  map <- ggplot(data = aleutians_full) +
-    geom_sf() +
-    geom_point(data = cog_360, 
-               aes(x = lon_360, y = est_lat, color = year), 
-               size = 1.5) +
-    geom_errorbar(data = cog_360, 
-                  aes(x = lon_360, ymin = lwr_lat, ymax = upr_lat, color = year), 
-                  alpha = 0.4, 
-                  orientation = "x", 
-                  width = 0) +
-    geom_errorbar(data = cog_360, 
-                  aes(y = est_lat, xmin = lwr_360, xmax = upr_360, color = year), 
-                  alpha = 0.4, 
-                  orientation = "y",
-                  width = 0) +
-    scale_color_viridis(name = "Year", option = "plasma", discrete = FALSE, end = 0.9) +
-    labs(x = NULL, y = NULL) +
-    scale_y_continuous(breaks = scales::pretty_breaks(n = 3)) +
-    scale_x_continuous(breaks = scales::pretty_breaks(n = 3)) +  # not working well!
-    facet_wrap(~species_code, ncol = 2) 
-}
+  # Set x-axis scale - THIS DOESN'T REALLY WORK
+  x_scale <- scale_x_continuous(breaks = c(175, 180, 185, 190))
+  # Map view limits (using 360 scale for X)
+  map_coord <- coord_sf(xlim = c(173, 190), ylim = c(50, 55), expand = FALSE, datum = NULL)
+  
+} 
 
 if(survey == "GOA") {
-  map <- ggplot(data = world) +
-    geom_sf() +
-    geom_point(data = cog_latlon, 
-               aes(x = est_lon, y = est_lat, color = year), 
-               size = 1.5) +
-    geom_errorbar(data = cog_latlon, 
-                  aes(x = est_lon, ymin = lwr_lat, ymax = upr_lat, color = year), 
-                  alpha = 0.4, 
-                  orientation = "x", 
-                  width = 0) +
-    geom_errorbar(data = cog_latlon, 
-                  aes(y = est_lat, xmin = lwr_lon, xmax = upr_lon, color = year), 
-                  alpha = 0.4, 
-                  orientation = "y",
-                  width = 0) +
-    coord_sf(xlim = c(-162.5, -140), ylim = c(54, 60), expand = FALSE) +
-    scale_color_viridis(name = "Year", option = "plasma", discrete = FALSE, end = 0.9) +
-    scale_x_continuous(breaks = c(-160, -145)) +
-    scale_y_continuous(breaks = c(55, 60)) +
-    labs(x = NULL, y = NULL) +
-    facet_wrap(~species_code, ncol = 2)
+  map_bg <- world
+  
+  # Prepare GOA data (standard coordinates)
+  map_data <- cog_latlon %>%
+    mutate(x_plot = est_lon, xmin_plot = lwr_lon, xmax_plot = upr_lon, y_plot = est_lat)
+  
+  x_scale <- scale_x_continuous(breaks = c(-160, -145))
+  map_coord <- coord_sf(xlim = c(-162.5, -140), ylim = c(54, 60), expand = FALSE)
 }
 
-map
+# Build layered plot, so more recent years are on top
+years_ordered <- sort(unique(map_data$year))
+
+year_layers <- purrr::map(years_ordered, ~{
+  year_subset <- filter(map_data, year == .x)
+  list(
+    geom_errorbar(data = year_subset, 
+                  aes(x = x_plot, ymin = lwr_lat, ymax = upr_lat, color = year), 
+                  alpha = 0.4, width = 0),
+    geom_errorbarh(data = year_subset, 
+                   aes(y = y_plot, xmin = xmin_plot, xmax = xmax_plot, color = year), 
+                   alpha = 0.4, height = 0),
+    geom_point(data = year_subset, 
+               aes(x = x_plot, y = y_plot, color = year), size = 1.5)
+  )
+})
+
+# Assemble the final plot
+map <- ggplot() +
+  geom_sf(data = map_bg, fill = "grey90", color = "grey60") +
+  year_layers + # The ordered layers from purrr
+  facet_wrap(~species_code, ncol = 2) +
+  scale_color_viridis(name = "Year", option = "plasma", end = 0.9) +
+  scale_y_continuous(breaks = scales::pretty_breaks(n = 3)) +
+  x_scale +
+  map_coord +
+  labs(x = NULL, y = NULL) 
+map  # view plot
 
 
 # Save plots ------------------------------------------------------------------

--- a/R/cog_plots.R
+++ b/R/cog_plots.R
@@ -228,10 +228,24 @@ map <- ggplot() +
   scale_color_viridis(name = "Year", option = "plasma", end = 0.9) +
   scale_y_continuous(breaks = scales::pretty_breaks(n = 3)) +
   x_scale +
-  map_coord +
-  labs(x = NULL, y = NULL) 
-map  # view plot
+  map_coord 
 
+# Add landmark label (Adak Island) for the AI maps
+if(survey == "AI") {
+  adak <- data.frame(label = "Adak", x = (-176.66 + 360), y = 51.88)
+  map <- map +
+    # First, remove lat & lon labels, because they don't really help!
+    theme(axis.title = element_blank(),
+          axis.text = element_blank(),
+          axis.ticks = element_blank()) +
+    ggrepel::geom_text_repel(data = adak, aes(x = x, y = y, label = label),
+                             size = 3, color = "grey40",
+                             nudge_x = 1, nudge_y = -0.7, 
+                             segment.color = "grey40", segment.size = 0.3, 
+                             direction = "both")
+}
+
+map  # view plot
 
 # Save plots ------------------------------------------------------------------
 # Create a directory for latest GOA survey year if it doesn't already exist

--- a/R/cog_plots.R
+++ b/R/cog_plots.R
@@ -162,56 +162,31 @@ sparkle
 world <- rnaturalearth::ne_countries(scale = "medium", returnclass = "sf")
 sf::sf_use_s2(FALSE)  # turn off spherical geometry
 
-map <- ggplot() +
-  geom_sf(data = world) +
-  geom_errorbar(
-    data = dplyr::filter(cog_sparkle, year ==  unique_years[1]), 
-    mapping = aes(x = est_lon, ymin = lwr_lat, ymax = upr_lat, color = year), 
-    alpha = 0.4,
-    width = 0) +
-  geom_errorbarh(
-    data = dplyr::filter(cog_sparkle, year ==  unique_years[1]),
-    mapping = aes(xmin = lwr_lon, xmax = upr_lon, y = est_lat, color = year), 
-    alpha = 0.4,
-    width = 0
-  ) +
-  geom_point(
-    data = dplyr::filter(cog_sparkle, year ==  unique_years[1]), 
-    mapping = aes(x = est_lon, y = est_lat, color = year),
-    size = 1.5
-  )
-  
-
-for(ii in 2:length(unique_years)) {
-  map <- 
-    map +
-    geom_errorbar(
-      data = dplyr::filter(cog_sparkle, year ==  unique_years[ii]), 
-      mapping = aes(x = est_lon, ymin = lwr_lat, ymax = upr_lat, color = year), 
-      alpha = 0.4,
-      width = 0) +
-    geom_errorbarh(
-      data = dplyr::filter(cog_sparkle, year ==  unique_years[ii]),
-      mapping = aes(xmin = lwr_lon, xmax = upr_lon, y = est_lat, color = year), 
-      alpha = 0.4,
-      width = 0
-    ) +
-    geom_point(
-      data = dplyr::filter(cog_sparkle, year ==  unique_years[ii]), 
-      mapping = aes(x = est_lon, y = est_lat, color = year),
-      size = 1.5
-    )
-  
-}
-
-map <- map + 
-  coord_sf(xlim = c(-180, -140), ylim = c(54, 60), expand = FALSE) +
+map <- ggplot(data = world) +
+  geom_sf() +
+  geom_point(data = cog_sparkle, aes(x = est_lon, y = est_lat, color = year), size = 1.5) +
+  geom_errorbar(data = cog_sparkle, aes(x = est_lon, ymin = lwr_lat, ymax = upr_lat, color = year), alpha = 0.4) +
+  geom_errorbarh(data = cog_sparkle, aes(y = est_lat, xmin = lwr_lon, xmax = upr_lon, color = year), alpha = 0.4) +
   scale_color_viridis(name = "Year", option = "plasma", discrete = FALSE, end = 0.9) +
-  scale_x_continuous(breaks = c(-160, -145)) +
-  scale_y_continuous(breaks = c(55, 60)) +
   labs(x = NULL, y = NULL) +
   facet_wrap(~species_code, ncol = 2)
+
+if(survey == "AI") {
+  map <- map +
+    coord_sf(xlim = c(-180, -170), ylim = c(51, 55), expand = FALSE) +
+    scale_x_continuous(breaks = c(-180, -170)) +
+    scale_y_continuous(breaks = c(51, 55)) 
+}
+
+if(survey == "GOA") {
+  map <- map +
+    coord_sf(xlim = c(-162.5, -140), ylim = c(54, 60), expand = FALSE) +
+    scale_x_continuous(breaks = c(-160, -145)) +
+    scale_y_continuous(breaks = c(55, 60)) 
+}
+
 map
+
 
 # Save plots ------------------------------------------------------------------
 # Create a directory for latest GOA survey year if it doesn't already exist
@@ -220,9 +195,9 @@ if (!dir.exists(dir)) {
   dir.create(dir)
 }
 
-ggsave(ts_plot, filename = here(dir, "rf_cog_ts.png"), 
+ggsave(ts_plot, filename = here(dir, paste0("rf_cog_ts_", survey, "_", ".png")), 
        width = 200, height = 110, unit = "mm", dpi = 300)
-ggsave(sparkle, filename = here(dir, "rf_cog_sparkle.png"), 
+ggsave(sparkle, filename = here(dir, paste0("rf_cog_sparkle_", survey, "_", ".png")), 
        width = 180, height = 150, unit = "mm", dpi = 300)
-ggsave(map, filename = here(dir, "rf_cog_map.png"), 
+ggsave(map, filename = here(dir, paste0("rf_cog_map_", survey, "_", ".png")), 
        width = 180, height = 140, unit = "mm", dpi = 300)

--- a/R/cog_plots.R
+++ b/R/cog_plots.R
@@ -16,7 +16,6 @@ library(dplyr)
 library(ggplot2)
 library(viridis)
 library(here)
-library(sp)
 library(sf)
 library(scales)
 library(reshape2)
@@ -106,16 +105,25 @@ colnames(cog_lat)[4:6] <- c("est_lat", "lwr_lat", "upr_lat")
 cog_lon <- coord_out[coord_out$metric == "Longitude", c(1:4, 6:7)]
 colnames(cog_lon)[4:6] <- c("est_lon", "lwr_lon", "upr_lon")
 
-# Correct "wrapping" around the IDL (only necessary for the AI)
-cog_lon <- cog_lon %>%
-  mutate(across(c(est_lon, lwr_lon, upr_lon), 
-                ~case_when(. > 0 ~ (((180 - .) + 180) * -1), 
-                           TRUE  ~ .)))
-
 # Combine with latitude
-cog_sparkle <- cog_lat %>% 
+cog_latlon <- cog_lat %>% 
   left_join(cog_lon, by = c("species_code", "year")) %>% 
   arrange(year)
+
+if(survey == "AI") {
+  # Correct "wrapping" around the IDL (only necessary for the AI)
+  cog_sparkle <- cog_lon %>%
+    mutate(across(c(est_lon, lwr_lon, upr_lon), 
+                  ~case_when(. > 0 ~ (((180 - .) + 180) * -1), 
+                             TRUE  ~ .))) %>%
+    left_join(cog_lat, by = c("species_code", "year")) %>% 
+    arrange(year)
+}
+
+if(survey == "GOA") {
+  # No correction needed, continue with original coordinates
+  cog_sparkle <- cog_latlon
+}
 
 # Build the base plot with facets and scales (but no data layers yet)
 years_ordered <- sort(unique(cog_sparkle$year)) # List of years
@@ -162,27 +170,63 @@ sparkle
 world <- rnaturalearth::ne_countries(scale = "medium", returnclass = "sf")
 sf::sf_use_s2(FALSE)  # turn off spherical geometry
 
-map <- ggplot(data = world) +
-  geom_sf() +
-  geom_point(data = cog_sparkle, aes(x = est_lon, y = est_lat, color = year), size = 1.5) +
-  geom_errorbar(data = cog_sparkle, aes(x = est_lon, ymin = lwr_lat, ymax = upr_lat, color = year), alpha = 0.4) +
-  geom_errorbarh(data = cog_sparkle, aes(y = est_lat, xmin = lwr_lon, xmax = upr_lon, color = year), alpha = 0.4) +
-  scale_color_viridis(name = "Year", option = "plasma", discrete = FALSE, end = 0.9) +
-  labs(x = NULL, y = NULL) +
-  facet_wrap(~species_code, ncol = 2)
-
 if(survey == "AI") {
-  map <- map +
-    coord_sf(xlim = c(-180, -170), ylim = c(51, 55), expand = FALSE) +
-    scale_x_continuous(breaks = c(-180, -170)) +
-    scale_y_continuous(breaks = c(51, 55)) 
+  # Subset world to Aleutian Islands region
+  western_half <- sf::st_crop(world, xmin = 170, xmax = 180, ymin = 48, ymax = 55)
+  eastern_half <- sf::st_crop(world, xmin = -180, xmax = -170, ymin = 48, ymax = 55)
+  aleutians_full <- bind_rows(western_half, eastern_half) %>%
+    sf::st_shift_longitude() 
+  
+  # Transform data to continuous scale across date line for plotting
+  cog_360 <- cog_latlon %>%
+    mutate(lon_360 = ifelse(est_lon < 0, est_lon + 360, est_lon),
+           lwr_360 = ifelse(lwr_lon < 0, lwr_lon + 360, lwr_lon),
+           upr_360 = ifelse(upr_lon < 0, upr_lon + 360, upr_lon))
+  
+  map <- ggplot(data = aleutians_full) +
+    geom_sf() +
+    geom_point(data = cog_360, 
+               aes(x = lon_360, y = est_lat, color = year), 
+               size = 1.5) +
+    geom_errorbar(data = cog_360, 
+                  aes(x = lon_360, ymin = lwr_lat, ymax = upr_lat, color = year), 
+                  alpha = 0.4, 
+                  orientation = "x", 
+                  width = 0) +
+    geom_errorbar(data = cog_360, 
+                  aes(y = est_lat, xmin = lwr_360, xmax = upr_360, color = year), 
+                  alpha = 0.4, 
+                  orientation = "y",
+                  width = 0) +
+    scale_color_viridis(name = "Year", option = "plasma", discrete = FALSE, end = 0.9) +
+    labs(x = NULL, y = NULL) +
+    scale_y_continuous(breaks = scales::pretty_breaks(n = 3)) +
+    scale_x_continuous(breaks = scales::pretty_breaks(n = 3)) +  # not working well!
+    facet_wrap(~species_code, ncol = 2) 
 }
 
 if(survey == "GOA") {
-  map <- map +
+  map <- ggplot(data = world) +
+    geom_sf() +
+    geom_point(data = cog_latlon, 
+               aes(x = est_lon, y = est_lat, color = year), 
+               size = 1.5) +
+    geom_errorbar(data = cog_latlon, 
+                  aes(x = est_lon, ymin = lwr_lat, ymax = upr_lat, color = year), 
+                  alpha = 0.4, 
+                  orientation = "x", 
+                  width = 0) +
+    geom_errorbar(data = cog_latlon, 
+                  aes(y = est_lat, xmin = lwr_lon, xmax = upr_lon, color = year), 
+                  alpha = 0.4, 
+                  orientation = "y",
+                  width = 0) +
     coord_sf(xlim = c(-162.5, -140), ylim = c(54, 60), expand = FALSE) +
+    scale_color_viridis(name = "Year", option = "plasma", discrete = FALSE, end = 0.9) +
     scale_x_continuous(breaks = c(-160, -145)) +
-    scale_y_continuous(breaks = c(55, 60)) 
+    scale_y_continuous(breaks = c(55, 60)) +
+    labs(x = NULL, y = NULL) +
+    facet_wrap(~species_code, ncol = 2)
 }
 
 map
@@ -190,7 +234,7 @@ map
 
 # Save plots ------------------------------------------------------------------
 # Create a directory for latest GOA survey year if it doesn't already exist
-dir <- here("output", paste0("plots ", yr_goa))
+dir <- here("output", paste0("plots ", yr))
 if (!dir.exists(dir)) {
   dir.create(dir)
 }

--- a/R/cog_plots.R
+++ b/R/cog_plots.R
@@ -1,12 +1,12 @@
-#' Plots of empirical center of gravity for GOA rockfish. COG is generated in 
-#' the cog.R script. 
+#' Plots of empirical center of gravity for rockfish. COG is generated in the 
+#' cog.R script. 
 #' 
 #' There are three plot types produced in this script:
 #' 1. Time series plot of depth, bottom temperature, eastings, and northings
 #'    for all species to facilitate direct comparisons.
 #' 2. 'Sparkle' plot - bivariate scatterplot of latitude and longitude to 
 #'    demonstrate changes in relative COG over time.
-#' 3. Map of COG relative to the GOA coastline. Most useful for nearshore 
+#' 3. Map of COG relative to the coastline. Most useful for nearshore 
 #'    species with limited distributions. May be misleading for stocks where
 #'    the empirical COG is outside of the survey domain.
 #'    
@@ -52,13 +52,16 @@ theme_set(theme_sleek())
 
 # Data import & cleaning ------------------------------------------------------
 # Either read in existing COG file, or calculate empirical cog using R script.
-# Set most recent GOA survey year
-yr_goa <- 2025
+## TODO: Set survey area
+survey <- c("AI", "GOA")[1]
 
-if (file.exists(here("output", paste0("rf_cogs_", yr_goa, ".csv")))) {
-  cogs <- read.csv(here("output", paste0("rf_cogs_", yr_goa, ".csv")))
+## TODO: Set latest GOA or AI survey year
+yr <- 2024
+
+if (file.exists(here("output", paste0("rf_cogs_", survey, "_", yr, ".csv")))) {
+  cogs <- read.csv(here("output", paste0("rf_cogs_", survey, "_", yr, ".csv")))
 } else {
-  # TODO: make sure you've updated cog.R to pull the most-recent GOA survey data!
+  # TODO: make sure you've updated cog.R to pull the correct survey data!
   source(here("R", "cog.R"))
 }
 
@@ -76,9 +79,9 @@ cogs_plot <- cogs %>%
   mutate(metric = case_when(
     metric == "BOTTOM_TEMPERATURE_C" ~ "Bottom Temp (\u00B0C)",
     metric == "DEPTH_M" ~ "Depth (m)",
-    metric == "LATITUDE_DD_START" ~ "Latitude",
-    metric == "LONGITUDE_DD_START" ~ "Longitude"
-  )) %>%
+    metric == "X" ~ "Eastings (km)",
+    metric == "Y" ~ "Northings (km)",
+    )) %>%
   # Remove first two dusky points (1990 & 1993; data should start in 1996)
   filter(!(species_code == "Dusky Rockfish" & year <= 1996)) %>% 
   # Make depth estimates negative for inverted axis when plotting
@@ -87,36 +90,10 @@ cogs_plot <- cogs %>%
          lwr = if_else(metric == "Depth (m)", -lwr, lwr))
 
 # Time series plot ------------------------------------------------------------
-# Transform latitude & longitude to UTM (for estimates, upper & lower bounds)
-utm_transform <- function(column) {
-  utm <- data.frame(Y = cogs_plot[cogs_plot$metric == "Latitude", column],
-                    X = cogs_plot[cogs_plot$metric == "Longitude", column],
-                    species_code = cogs_plot[cogs_plot$metric == "Longitude", "species_code"], 
-                    year = cogs_plot[cogs_plot$metric == "Longitude", "year"])
-  
-  sp::coordinates(utm) <- ~ X + Y
-  sp::proj4string(utm) <- sp::CRS("+proj=longlat +datum=WGS84")
-  utm <- as.data.frame(sp::spTransform(utm, sp::CRS("+proj=utm +zone=5 +units=km")))
-  colnames(utm)[c(3:4)] <- c("Eastings (km)", "Northings (km)")
-  
-  utm <- reshape2::melt(utm, 
-                        id.vars = c("species_code", "year"), 
-                        variable.name = "metric",
-                        value.name = column)
-  return(utm)
-}
-
-utm_out <- cbind.data.frame(utm_transform("est"),
-                            se = utm_transform("se")$se,
-                            lwr = utm_transform("lwr")$lwr,
-                            upr = utm_transform("upr")$upr)
-
 # Special colors from naturalparkcolors::park_palette("Saguaro)
 pal <- c("#847CA3", "#E45A5A", "#F4A65E", "#80792B", "#F2D56F", "#1A1237")
 
-ts_plot <- rbind.data.frame(cogs_plot %>% filter(!metric %in% c("Latitude", "Longitude")),
-                            utm_out[, c(3, 1, 2, 4:7)]) %>%  # Combine original & UTM dataframes
-  ggplot(., aes(x = year, y = est)) +
+ts_plot <- ggplot(cogs_plot, aes(x = year, y = est)) +
   geom_line(aes(color = species_code)) +
   geom_ribbon(aes(ymin = lwr, ymax = upr, fill = species_code), alpha = 0.4) +
   xlab("Year") + ylab("Weighted Mean") +
@@ -128,10 +105,35 @@ ts_plot <- rbind.data.frame(cogs_plot %>% filter(!metric %in% c("Latitude", "Lon
 ts_plot
 
 # Sparkleplot (bivariate scatter plot for lat & lon) --------------------------
-cog_lat <- cogs_plot[cogs_plot$metric == "Latitude", c(2:4, 6:7)]
-colnames(cog_lat)[3:5] <- c("est_lat", "lwr_lat", "upr_lat")
-cog_lon <- cogs_plot[cogs_plot$metric == "Longitude", c(2:4, 6:7)]
-colnames(cog_lon)[3:5] <- c("est_lon", "lwr_lon", "upr_lon")
+# Transform UTM to latitude/longidue (for estimates, upper & lower bounds)
+coord_transform <- function(column) {
+  utm <- data.frame(Y = cogs_plot[cogs_plot$metric == "Northings (km)", column],
+                    X = cogs_plot[cogs_plot$metric == "Eastings (km)", column])
+  latlon <- sf::st_as_sf(utm,
+                         coords = c("X", "Y"),
+                         crs = "+proj=utm +zone=5 +datum=WGS84 +units=km")
+  latlon <- sf::st_transform(latlon, crs = 4326)
+  latlon <- data.frame(sf::st_coordinates(latlon))
+  latlon_out <- cbind.data.frame(species_code = cogs_plot[cogs_plot$metric == "Eastings (km)", "species_code"],
+                                 year = cogs_plot[cogs_plot$metric == "Eastings (km)", "year"],
+                                 Latitude = latlon$Y,
+                                 Longitude = latlon$X)
+  latlon_out <- reshape2::melt(latlon_out, 
+                               id.vars = c("species_code", "year"), 
+                               variable.name = "metric",
+                               value.name = column)
+  return(latlon_out)
+}
+
+coord_out <- cbind.data.frame(coord_transform("est"),
+                              se = coord_transform("se")$se,
+                              lwr = coord_transform("lwr")$lwr,
+                              upr = coord_transform("upr")$upr)
+
+cog_lat <- coord_out[coord_out$metric == "Latitude", c(1:4, 6:7)]
+colnames(cog_lat)[4:6] <- c("est_lat", "lwr_lat", "upr_lat")
+cog_lon <- coord_out[coord_out$metric == "Longitude", c(1:4, 6:7)]
+colnames(cog_lon)[4:6] <- c("est_lon", "lwr_lon", "upr_lon")
 
 cog_sparkle <- cog_lat %>% left_join(cog_lon, by = c("species_code", "year"))
 

--- a/R/cog_plots.R
+++ b/R/cog_plots.R
@@ -23,47 +23,19 @@ library(reshape2)
 library(rnaturalearth)
 library(rnaturalearthdata)
 
-# Set ggplot theme
-# theme_sleek() from ggsidekick (github.com/seananderson/ggsidekick)
-theme_sleek <- function(base_size = 11, base_family = "") {
-  half_line <- base_size/2
-  theme_light(base_size = base_size, base_family = base_family) +
-    theme(
-      panel.grid.major = element_blank(),
-      panel.grid.minor = element_blank(),
-      axis.ticks.length = unit(half_line / 2.2, "pt"),
-      strip.background = element_rect(fill = NA, colour = NA),
-      strip.text.x = element_text(colour = "grey30"),
-      strip.text.y = element_text(colour = "grey30"),
-      axis.text = element_text(colour = "grey30"),
-      axis.title = element_text(colour = "grey30"),
-      legend.title = element_text(colour = "grey30", size = rel(0.9)),
-      panel.border = element_rect(fill = NA, colour = "grey70", linewidth = 1),
-      legend.key.size = unit(0.9, "lines"),
-      legend.text = element_text(size = rel(0.7), colour = "grey30"),
-      legend.key = element_rect(colour = NA, fill = NA),
-      legend.background = element_rect(colour = NA, fill = NA),
-      plot.title = element_text(colour = "grey30", size = rel(1)),
-      plot.subtitle = element_text(colour = "grey30", size = rel(.85))
-    )
-}
+# Set up plot aesthetics (ggplot theme, color palette)
+source(here("R", "aesthetics.R"))
 
-theme_set(theme_sleek())
 
-# Data import & cleaning ------------------------------------------------------
-# Either read in existing COG file, or calculate empirical cog using R script.
-## TODO: Set survey area
+# Set up and run empirical COG; clean up data ---------------------------------
+# TODO: Set survey area
 survey <- c("AI", "GOA")[1]
 
-## TODO: Set latest GOA or AI survey year
-yr <- 2024
+# Set year to current year
+yr <- as.numeric(format(Sys.Date(), "%Y"))
 
-if (file.exists(here("output", paste0("rf_cogs_", survey, "_", yr, ".csv")))) {
-  cogs <- read.csv(here("output", paste0("rf_cogs_", survey, "_", yr, ".csv")))
-} else {
-  # TODO: make sure you've updated cog.R to pull the correct survey data!
-  source(here("R", "cog.R"))
-}
+# Calculate empirical cog using R script.
+source(here("R", "cog.R"))
 
 # Update dataframe to have common names, cleaner labels, correct axis
 cogs_plot <- cogs %>%
@@ -89,10 +61,8 @@ cogs_plot <- cogs %>%
          upr = if_else(metric == "Depth (m)", -upr, upr),
          lwr = if_else(metric == "Depth (m)", -lwr, lwr))
 
-# Time series plot ------------------------------------------------------------
-# Special colors from naturalparkcolors::park_palette("Saguaro)
-pal <- c("#847CA3", "#E45A5A", "#F4A65E", "#80792B", "#F2D56F", "#1A1237")
 
+# Time series plot ------------------------------------------------------------
 ts_plot <- ggplot(cogs_plot, aes(x = year, y = est)) +
   geom_line(aes(color = species_code)) +
   geom_ribbon(aes(ymin = lwr, ymax = upr, fill = species_code), alpha = 0.4) +
@@ -103,6 +73,7 @@ ts_plot <- ggplot(cogs_plot, aes(x = year, y = est)) +
   scale_y_continuous(labels = function(est) abs(est)) +
   facet_wrap(~ metric, scales = "free_y") 
 ts_plot
+
 
 # Sparkleplot (bivariate scatter plot for lat & lon) --------------------------
 # Transform UTM to latitude/longidue (for estimates, upper & lower bounds)

--- a/R/cog_plots.R
+++ b/R/cog_plots.R
@@ -30,9 +30,6 @@ source(here("R", "aesthetics.R"))
 # TODO: Set survey area
 survey <- c("AI", "GOA")[1]
 
-# Set year to current year
-yr <- as.numeric(format(Sys.Date(), "%Y"))
-
 # Calculate empirical cog using R script.
 source(here("R", "cog.R"))
 
@@ -75,14 +72,15 @@ ts_plot  # view plot
 
 
 # Sparkleplot (bivariate scatter plot for lat & lon) --------------------------
-# Transform UTM to latitude/longidue (for estimates, upper & lower bounds)
-coord_transform <- function(column) {
-  utm <- data.frame(Y = cogs_plot[cogs_plot$metric == "Northings (km)", column],
-                    X = cogs_plot[cogs_plot$metric == "Eastings (km)", column])
-  latlon <- sf::st_as_sf(utm,
+# Transform Alaska Albers to latitude/longidue (for estimates, upper & lower bounds)
+coord_transform <- function(column, crs) {
+  # Pull out geographic info and convert back to m so conversion will work
+  aa <- bind_cols(Y = cogs_plot[cogs_plot$metric == "Northings (km)", column] * 1000,
+                  X = cogs_plot[cogs_plot$metric == "Eastings (km)", column] * 1000)
+  latlon <- sf::st_as_sf(aa,
                          coords = c("X", "Y"),
-                         crs = "+proj=utm +zone=5 +datum=WGS84 +units=km")
-  latlon <- sf::st_transform(latlon, crs = 4326)
+                         crs = 3338)
+  latlon <- sf::st_transform(latlon, crs = crs)
   latlon <- data.frame(sf::st_coordinates(latlon))
   latlon_out <- cbind.data.frame(species_code = cogs_plot[cogs_plot$metric == "Eastings (km)", "species_code"],
                                  year = cogs_plot[cogs_plot$metric == "Eastings (km)", "year"],
@@ -95,10 +93,10 @@ coord_transform <- function(column) {
   return(latlon_out)
 }
 
-coord_out <- cbind.data.frame(coord_transform("est"),
-                              se = coord_transform("se")$se,
-                              lwr = coord_transform("lwr")$lwr,
-                              upr = coord_transform("upr")$upr)
+coord_out <- cbind.data.frame(coord_transform("est", 4326),
+                              se = coord_transform("se", 4326)$se,
+                              lwr = coord_transform("lwr", 4326)$lwr,
+                              upr = coord_transform("upr", 4326)$upr)
 
 cog_lat <- coord_out[coord_out$metric == "Latitude", c(1:4, 6:7)]
 colnames(cog_lat)[4:6] <- c("est_lat", "lwr_lat", "upr_lat")

--- a/R/cog_plots.R
+++ b/R/cog_plots.R
@@ -135,22 +135,21 @@ colnames(cog_lat)[4:6] <- c("est_lat", "lwr_lat", "upr_lat")
 cog_lon <- coord_out[coord_out$metric == "Longitude", c(1:4, 6:7)]
 colnames(cog_lon)[4:6] <- c("est_lon", "lwr_lon", "upr_lon")
 
-# Correct "wrapping" around the IDL
+# Correct "wrapping" around the IDL (only necessary for the AI)
 cog_lon <- cog_lon %>%
   mutate(across(c(est_lon, lwr_lon, upr_lon), 
                 ~case_when(. > 0 ~ (((180 - .) + 180) * -1), 
                            TRUE  ~ .)))
 
-# Combine with latitude and plot
-cog_sparkle <- cog_lat %>% left_join(cog_lon, by = c("species_code", "year")) %>% arrange(year)
-  
-# List of years
-years_ordered <- sort(unique(cog_sparkle$year))
+# Combine with latitude
+cog_sparkle <- cog_lat %>% 
+  left_join(cog_lon, by = c("species_code", "year")) %>% 
+  arrange(year)
 
 # Build the base plot with facets and scales (but no data layers yet)
+years_ordered <- sort(unique(cog_sparkle$year)) # List of years
 sparkle <- ggplot(cog_sparkle, aes(color = year)) +
   scale_color_viridis(name = "Year", option = "plasma", end = 0.9) +
-  scale_x_continuous(breaks = c(-185, -180, -175), labels = c(175, 0, -175)) +
   scale_y_continuous(breaks = scales::pretty_breaks(n = 3)) +
   facet_wrap(~species_code, ncol = 2) +
   labs(x = "Longitude (\u00B0W)", y = "Latitude (\u00B0N)")
@@ -175,6 +174,16 @@ year_layers <- purrr::map(years_ordered, ~{
 
 # Add layers to the plot
 sparkle <- sparkle + year_layers
+
+# Set x-axis labels based on survey region
+if(survey == "GOA") {
+  sparkle <- sparkle + 
+    scale_x_continuous(breaks = scales::pretty_breaks(n = 3))
+}
+if(survey == "AI") {
+  sparkle <- sparkle + 
+    scale_x_continuous(breaks = c(-185, -180, -175), labels = c(175, 0, -175)) 
+}
 sparkle
 
 

--- a/R/cog_plots.R
+++ b/R/cog_plots.R
@@ -30,9 +30,6 @@ source(here("R", "aesthetics.R"))
 # TODO: Set survey area
 survey <- c("AI", "GOA")[1]
 
-# Set year to current year
-yr <- as.numeric(format(Sys.Date(), "%Y"))
-
 # Calculate empirical cog using R script.
 source(here("R", "cog.R"))
 
@@ -58,7 +55,7 @@ cogs_plot <- cogs %>%
   # Make depth estimates negative for inverted axis when plotting
   mutate(est = if_else(metric == "Depth (m)", -est, est),
          upr = if_else(metric == "Depth (m)", -upr, upr),
-         lwr = if_else(metric == "Depth (m)", -lwr, lwr))
+         lwr = if_else(metric == "Depth (m)", -lwr, lwr)) 
 
 
 # Time series plot ------------------------------------------------------------
@@ -75,14 +72,15 @@ ts_plot  # view plot
 
 
 # Sparkleplot (bivariate scatter plot for lat & lon) --------------------------
-# Transform UTM to latitude/longidue (for estimates, upper & lower bounds)
-coord_transform <- function(column) {
-  utm <- data.frame(Y = cogs_plot[cogs_plot$metric == "Northings (km)", column],
-                    X = cogs_plot[cogs_plot$metric == "Eastings (km)", column])
-  latlon <- sf::st_as_sf(utm,
+# Transform Alaska Albers to latitude/longidue (for estimates, upper & lower bounds)
+coord_transform <- function(column, crs) {
+  # Pull out geographic info and convert back to m so conversion will work
+  aa <- bind_cols(Y = cogs_plot[cogs_plot$metric == "Northings (km)", column] * 1000,
+                  X = cogs_plot[cogs_plot$metric == "Eastings (km)", column] * 1000)
+  latlon <- sf::st_as_sf(aa,
                          coords = c("X", "Y"),
-                         crs = "+proj=utm +zone=5 +datum=WGS84 +units=km")
-  latlon <- sf::st_transform(latlon, crs = 4326)
+                         crs = 3338)
+  latlon <- sf::st_transform(latlon, crs = crs)
   latlon <- data.frame(sf::st_coordinates(latlon))
   latlon_out <- cbind.data.frame(species_code = cogs_plot[cogs_plot$metric == "Eastings (km)", "species_code"],
                                  year = cogs_plot[cogs_plot$metric == "Eastings (km)", "year"],
@@ -95,10 +93,10 @@ coord_transform <- function(column) {
   return(latlon_out)
 }
 
-coord_out <- cbind.data.frame(coord_transform("est"),
-                              se = coord_transform("se")$se,
-                              lwr = coord_transform("lwr")$lwr,
-                              upr = coord_transform("upr")$upr)
+coord_out <- cbind.data.frame(coord_transform("est", 4326),
+                              se = coord_transform("se", 4326)$se,
+                              lwr = coord_transform("lwr", 4326)$lwr,
+                              upr = coord_transform("upr", 4326)$upr)
 
 cog_lat <- coord_out[coord_out$metric == "Latitude", c(1:4, 6:7)]
 colnames(cog_lat)[4:6] <- c("est_lat", "lwr_lat", "upr_lat")
@@ -211,10 +209,14 @@ year_layers <- purrr::map(years_ordered, ~{
   list(
     geom_errorbar(data = year_subset, 
                   aes(x = x_plot, ymin = lwr_lat, ymax = upr_lat, color = year), 
-                  alpha = 0.4, width = 0),
-    geom_errorbarh(data = year_subset, 
-                   aes(y = y_plot, xmin = xmin_plot, xmax = xmax_plot, color = year), 
-                   alpha = 0.4, height = 0),
+                  alpha = 0.4, 
+                  width = 0, 
+                  orientation = "x"),
+    geom_errorbar(data = year_subset, 
+                  aes(y = y_plot, xmin = xmin_plot, xmax = xmax_plot, color = year), 
+                  alpha = 0.4,
+                  width = 0, 
+                  orientation = "y"),
     geom_point(data = year_subset, 
                aes(x = x_plot, y = y_plot, color = year), size = 1.5)
   )
@@ -228,7 +230,8 @@ map <- ggplot() +
   scale_color_viridis(name = "Year", option = "plasma", end = 0.9) +
   scale_y_continuous(breaks = scales::pretty_breaks(n = 3)) +
   x_scale +
-  map_coord 
+  map_coord +
+  xlab("") + ylab("")
 
 # Add landmark label (Adak Island) for the AI maps
 if(survey == "AI") {

--- a/R/cog_plots.R
+++ b/R/cog_plots.R
@@ -135,57 +135,48 @@ colnames(cog_lat)[4:6] <- c("est_lat", "lwr_lat", "upr_lat")
 cog_lon <- coord_out[coord_out$metric == "Longitude", c(1:4, 6:7)]
 colnames(cog_lon)[4:6] <- c("est_lon", "lwr_lon", "upr_lon")
 
-cog_sparkle <- cog_lat %>% left_join(cog_lon, by = c("species_code", "year"))
+# Correct "wrapping" around the IDL
+cog_lon <- cog_lon %>%
+  mutate(across(c(est_lon, lwr_lon, upr_lon), 
+                ~case_when(. > 0 ~ (((180 - .) + 180) * -1), 
+                           TRUE  ~ .)))
 
-unique_years <- sort(unique(cog_sparkle$year))
-
-# Iteratively add years and error bars so the most recent year is on top
-sparkle <- ggplot() +
-  geom_errorbar(
-    data = dplyr::filter(cog_sparkle, year ==  unique_years[1]), 
-                mapping = aes(x = est_lon, ymin = lwr_lat, ymax = upr_lat, color = year), 
-    alpha = 0.4,
-    width = 0) +
-  geom_errorbarh(
-    data = dplyr::filter(cog_sparkle, year ==  unique_years[1]),
-                 mapping = aes(xmin = lwr_lon, xmax = upr_lon, y = est_lat, color = year), 
-    alpha = 0.4,
-    width = 0
-    ) +
-  geom_point(
-    data = dplyr::filter(cog_sparkle, year ==  unique_years[1]), 
-             mapping = aes(x = est_lon, y = est_lat, color = year)
-    )
-
-for(ii in 2:length(unique_years)) {
-  sparkle <- 
-    sparkle +
-    geom_errorbar(
-      data = dplyr::filter(cog_sparkle, year ==  unique_years[ii]), 
-      mapping = aes(x = est_lon, ymin = lwr_lat, ymax = upr_lat, color = year), 
-      alpha = 0.4,
-      width = 0) +
-    geom_errorbarh(
-      data = dplyr::filter(cog_sparkle, year ==  unique_years[ii]),
-      mapping = aes(xmin = lwr_lon, xmax = upr_lon, y = est_lat, color = year), 
-      alpha = 0.4,
-      width = 0
-    ) +
-    geom_point(
-      data = dplyr::filter(cog_sparkle, year ==  unique_years[ii]), 
-      mapping = aes(x = est_lon, y = est_lat, color = year)
-    )
+# Combine with latitude and plot
+cog_sparkle <- cog_lat %>% left_join(cog_lon, by = c("species_code", "year")) %>% arrange(year)
   
-}
+# List of years
+years_ordered <- sort(unique(cog_sparkle$year))
 
-sparkle <- 
-  sparkle +
-  scale_color_viridis(name = "Year", option = "plasma", discrete = FALSE, end = 0.9) +
-  xlab("Longitude (\u00B0W)") + ylab("Latitude (\u00B0N)") +
-  scale_x_continuous(breaks = scales::pretty_breaks(n = 3)) +
+# Build the base plot with facets and scales (but no data layers yet)
+sparkle <- ggplot(cog_sparkle, aes(color = year)) +
+  scale_color_viridis(name = "Year", option = "plasma", end = 0.9) +
+  scale_x_continuous(breaks = c(-185, -180, -175), labels = c(175, 0, -175)) +
   scale_y_continuous(breaks = scales::pretty_breaks(n = 3)) +
-  facet_wrap(~species_code, ncol = 2)
+  facet_wrap(~species_code, ncol = 2) +
+  labs(x = "Longitude (\u00B0W)", y = "Latitude (\u00B0N)")
+
+# Create a list of error bars & points for each year
+year_layers <- purrr::map(years_ordered, ~{
+  year_data <- filter(cog_sparkle, year == .x)
+  list(
+    geom_errorbar(data = year_data, 
+                  aes(x = est_lon, ymin = lwr_lat, ymax = upr_lat), 
+                  alpha = 0.4, 
+                  orientation = "x", 
+                  width = 0),
+    geom_errorbar(data = year_data, 
+                  aes(y = est_lat, xmin = lwr_lon, xmax = upr_lon), 
+                  alpha = 0.4, 
+                  orientation = "y",
+                  width = 0),
+    geom_point(data = year_data, aes(x = est_lon, y = est_lat))
+  )
+})
+
+# Add layers to the plot
+sparkle <- sparkle + year_layers
 sparkle
+
 
 # Maps ------------------------------------------------------------------------
 world <- rnaturalearth::ne_countries(scale = "medium", returnclass = "sf")
@@ -234,7 +225,7 @@ for(ii in 2:length(unique_years)) {
 }
 
 map <- map + 
-  coord_sf(xlim = c(-162.5, -140), ylim = c(54, 60), expand = FALSE) +
+  coord_sf(xlim = c(-180, -140), ylim = c(54, 60), expand = FALSE) +
   scale_color_viridis(name = "Year", option = "plasma", discrete = FALSE, end = 0.9) +
   scale_x_continuous(breaks = c(-160, -145)) +
   scale_y_continuous(breaks = c(55, 60)) +


### PR DESCRIPTION
Refactored GOA COG code to work for AI rockfish. This involved the following changes:

1. Added a switch for AI/GOA to `cog.R`. By default, the code is run with the current year and will pull all of the data for the selected survey region.
2. Start latitude and longitude for each observation is now transformed to Alaska Albers (updated 3/26 from UTM) before the COG is calculated, then transformed back to latitude and longitude for the sparkle and map plots. This is necessary for the AI because the region extends across the 180°W/E meridian, requiring a continuous coordinate system. For consistency, COG for both regions is now calculated in Alaska Albers.
3. Using `sf` instead of `sp` for spatial transformations.
4. Separate plotting for the AI, due to different extents and the coordinate system issue mentioned above. I also simplified the point-layering code to preserve plotting the points and lines for the most-recent year on top. There are still improvements to be made to the x-axis labeling for the map.
5. Moved aesthetics (ggplot theme and color palette) to a separate script (`aesthetics.R`) sourced by `cog_plots.R`.
6. Removed any user-defined variables from `cog.R`. Now, everything is defined in `cog_plots.R` and `cog.R` can be sourced from the plotting script. I will need to test the oracle connection when you don't have your credentials saved to the Z-drive.

<img width="2125" height="1653" alt="rf_cog_map_AI_" src="https://github.com/user-attachments/assets/cd8c2125-ab26-48e9-a124-f04d8ac03747" />
<img width="2125" height="1771" alt="rf_cog_sparkle_AI_" src="https://github.com/user-attachments/assets/f0f4302a-83e7-4602-b67b-6e63be4c2dc2" />
<img width="2362" height="1299" alt="rf_cog_ts_AI_" src="https://github.com/user-attachments/assets/c9ab58bb-b8f1-479e-a623-200ee404d81f" />
